### PR TITLE
from nlp_architect.utils.io import check_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The current version of NLP Architect includes these features that we found inter
 
 <center> <img src="doc/source/assets/nlp_archtiect_v0.1.png"></center>
 
-The library consists of core modules (topologies), data pipelines, utilities and end-to-end model examples with training and inference scripts. We look at these as a set of building blocks that were needed for implementing NLP use cases based on our pragmatic research experience. Each of the models includes algorithm descriptions and results in the [documentation](http://www.nlp_architect.nervanasys.com/).
+The library consists of core modules (topologies), data pipelines, utilities and end-to-end model examples with training and inference scripts. We look at these as a set of building blocks that were needed for implementing NLP use cases based on our pragmatic research experience. Each of the models includes algorithm descriptions and results in the [documentation](http://nlp_architect.nervanasys.com).
 
 Some of the components, with provided pre-trained models, are exposed as REST service APIs through NLP Architect server. NLP Architect server is designed to provide predictions across different models in NLP Architect. It also includes a web front-end exposing the model annotations for visualizations. Currently, we provide 2 services, BIST dependency parsing and NER annotations. We also provide a template for developers to add a new service.
 
@@ -36,7 +36,7 @@ Because of its current research nature, several open source deep learning framew
 Overtime the list of models included in this space will change, though all generally run with Python 3.5+
 
 ## Documentation
-Framework documentation on NLP model, algorithms, and modules, and instructions on how to contribute can be found [here](http://www.nlp_architect.nervanasys.com/).
+Framework documentation on NLP model, algorithms, and modules, and instructions on how to contribute can be found [here](http://nlp_architect.nervanasys.com).
 
 ## Installation
 

--- a/examples/memn2n_dialogue/interactive.py
+++ b/examples/memn2n_dialogue/interactive.py
@@ -51,7 +51,7 @@ import ngraph.transformers as ngt
 from nlp_architect.data.babi_dialog import BABI_Dialog
 from nlp_architect.models.memn2n_dialogue import MemN2N_Dialog
 from utils import interactive_loop
-from nlp_architect.utils.io import validate_existing_filepath, validate_parent_exists, validate
+from nlp_architect.utils.io import check_size, validate_existing_filepath, validate_parent_exists, validate
 
 # parse the command line arguments
 parser = NgraphArgparser(__doc__)


### PR DESCRIPTION
__check_size()__ is called on line 100 but is never imported.

flake8 testing of https://github.com/NervanaSystems/nlp-architect on Python 3.6.3

4 __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./examples/memn2n_dialogue/interactive.py:100:12: F821 undefined name 'check_size'
    action=check_size(1e-100,1e-2))
           ^
./nlp_architect/contrib/ngraph/match_lstm.py:688:38: F821 undefined name 'out_axes'
        states = {k: ng.cast_role(v, out_axes)
                                     ^
./nlp_architect/contrib/ngraph/weight_initilizers.py:31:31: F821 undefined name 'rng'
        return lambda w_axes: rng.normal(0, 1, w_axes)
                              ^
./nlp_architect/contrib/ngraph/weight_initilizers.py:61:19: F821 undefined name 'rng'
            name: rng.uniform(-1, 1, ax_s) for name in ['h', 'c']}
                  ^
4     F821 undefined name 'check_size'
4
```