### PR TITLE
Fix marking char removal

### DIFF
--- a/nlp_architect/models/np2vec.py
+++ b/nlp_architect/models/np2vec.py
@@ -171,9 +171,7 @@ class NP2vec:
 
         if word_embedding_type == 'fasttext' and word_ngrams == 1:
             # remove the marking character at the end for subword fasttext model training
-            for i, sentence in enumerate(self._sentences):
-                self._sentences[i] = [
-                    w[:-1] if self.is_marked(w) else w for w in sentence]
+            self._sentences = [[w[:-1] if self.is_marked(w) else w for w in sentence] for sentence in self._sentences]
 
         logger.info('training np2vec model')
         self._train()


### PR DESCRIPTION
The character removal loop for FastText with txt corpus format is currently not working, as the `_senteces` property is a `LineSentece` object that is not assignable. This change fixes that, by simply assigning a new value to `_sentences`.