### PR TITLE
Added matplotlib to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ pillow
 hug
 falcon
 falcon_multipart
+matplotlib


### PR DESCRIPTION
matplotlib is required to run [Deep_Learning_Sentiment_Demo.ipynb](https://github.com/NervanaSystems/nlp-architect/blob/master/tutorials/sentiment/Deep_Learning_Sentiment_Demo.ipynb).