### PR TITLE
Fixed parsed data path r comprehension

### DIFF
--- a/examples/reading_comprehension/prepare_data.py
+++ b/examples/reading_comprehension/prepare_data.py
@@ -72,10 +72,10 @@ def get_glove_matrix(vocabulary_list, download_path):
     """
     Function to obtain preprocessed glove embeddings matrix
     """
-    save_file_name = download_path + "glove.trimmed.300"
+    save_file_name = download_path + "/glove.trimmed.300"
     if not os.path.exists(save_file_name + ".npz"):
         vocab_len = len(vocabulary_list)
-        glove_path = os.path.join(download_path + "glove.6B.300d.txt")
+        glove_path = os.path.join(download_path + "/glove.6B.300d.txt")
         glove_matrix = np.zeros((vocab_len, 300))
         count = 0
         with open(glove_path) as f:
@@ -253,13 +253,13 @@ if __name__ == '__main__':
     dev_para_ids = get_ids_list(dev_para, vocab_dict)
     dev_question_ids = get_ids_list(dev_question, vocab_dict)
 
-    final_data_dict = {"train.ids.context": train_para_ids,
-                       "train.ids.question": train_question_ids,
-                       "dev.ids.context": dev_para_ids,
-                       "dev.ids.question": dev_question_ids,
-                       "vocab.dat": vocab_list,
-                       "train.span": train_ans,
-                       "dev.span": dev_ans}
+    final_data_dict = {"/train.ids.context": train_para_ids,
+                       "/train.ids.question": train_question_ids,
+                       "/dev.ids.context": dev_para_ids,
+                       "/dev.ids.question": dev_question_ids,
+                       "/vocab.dat": vocab_list,
+                       "/train.span": train_ans,
+                       "/dev.span": dev_ans}
 
     print("writing data to files")
     write_to_file(final_data_dict, data_path)


### PR DESCRIPTION
I've fixed the "prepare_data.py" file from the reading comprehension file, so the parsed data could be written in the path "data/name.of.file". It was concating the path to dataname.of.file, and so the "train.py" was not able to run. 
Did the same thing with the glove files.

I also created the "data" directory in this folder with the squad dataset v1.1, as it is not avaliable to download anymore and the 2.0 version does not work in this example.