### PR TITLE
Export & Import of Trained Quantized Models in 8bit Representation

### DIFF
--- a/docs-source/source/quantized_bert.rst
+++ b/docs-source/source/quantized_bert.rst
@@ -34,7 +34,7 @@ accelarating computation, true quantization must be applied using
 optimized kernels and dedicated hardware.
 
 .. note::
-    The :py:class:`QuantizedBertModel <nlp_architect.models.transformers.quantized_bert.QuantizedBertModel>` is only simulating quantization, meaning, the model is saved and computed using FP32 representation. During inference quantization is done online using Int8 values represented and computed with FP32 tensors.
+    :py:class:`QuantizedBertModel <nlp_architect.models.transformers.quantized_bert.QuantizedBertModel>` class does not make use of optimized Integer kernels for quantized Matrix Multiplication. Therefore, we expect that quantized inference will be slower than regular inference since quantization and dequantization operations are added to the unoptimized compute graph.
 
 Quantization Aware Training
 ===========================
@@ -104,6 +104,10 @@ To train Quantized BERT use the following code snippet:
         --data_dir /path/to/MRPC \
         --do_lower_case
 
+The model is saved at the end of training in 2 files:
+   1. A model saved in FP32 for further ``pytorch_model.bin``
+   2. A quantized model for inference only ``quant_pytorch_model.bin``
+
 Inference
 ---------
 To run inference with a fine tuned quantized BERT use the
@@ -120,8 +124,11 @@ following code snippet:
         --do_lower_case \
         --overwrite_output_dir
 
-To run evaluation on the task's development set add the flag ``--evaluate``
-to the command line.
+- To run evaluation on the task's development set add the flag ``--evaluate``
+  to the command line.
+- To run the quantized model saved in ``quant_pytorch_model.bin`` add the flag
+  ``--load_quantized_model`` to the command line.
+
 
 References
 ==========

--- a/nlp_architect/common/config.py
+++ b/nlp_architect/common/config.py
@@ -28,9 +28,13 @@ import abc
 
 class Config(abc.ABC):
     """Quantization Configuration Object"""
-    @abc.abstractmethod
-    def __init__(self):
-        pass
+    ATTRIBUTES = {}
+
+    def __init__(self, **kwargs):
+        for entry in self.ATTRIBUTES:
+            setattr(self, entry, kwargs.pop(entry, self.ATTRIBUTES[entry]))
+        if kwargs:
+            raise TypeError(f"got an unexpected keyword argument: {list(kwargs.keys())}")
 
     @classmethod
     def from_dict(cls, json_object):

--- a/nlp_architect/models/transformers/quantized_bert.py
+++ b/nlp_architect/models/transformers/quantized_bert.py
@@ -221,7 +221,7 @@ class QuantizedBertPreTrainedModel(BertPreTrainedModel):
 
         # Instantiate model.
         model = cls(config)
-        # Set model in evaluation mode to desactivate DropOut modules by default
+        # Set model to initialize variables to be loaded from quantized checkpoint which are None by Default
         model.eval()
         # Get state dict of model
         state_dict = torch.load(model_file, map_location='cpu')
@@ -285,10 +285,10 @@ class QuantizedBertPreTrainedModel(BertPreTrainedModel):
         model_to_save.toggle_8bit(False)
 
     def toggle_8bit(self, mode: bool):
-        def toggle_8bit(module):
+        def _toggle_8bit(module):
             if isinstance(module, QuantizedLayer):
-                module.toggle_8bit = mode
-        self.apply(toggle_8bit)
+                module.mode_8bit = mode
+        self.apply(_toggle_8bit)
         if mode:
             training = self.training
             self.eval()

--- a/nlp_architect/models/transformers/quantized_bert.py
+++ b/nlp_architect/models/transformers/quantized_bert.py
@@ -19,7 +19,10 @@ Quantized BERT layers and model
 """
 
 import sys
+import os
+import logging
 
+import torch
 from torch import nn
 from pytorch_transformers.modeling_bert import (BertEmbeddings,
                                                 BertLayerNorm,
@@ -40,8 +43,13 @@ from pytorch_transformers.modeling_bert import (BertEmbeddings,
                                                 BertConfig)
 
 from nlp_architect.nn.torch.quantization import (QuantizationConfig,
+                                                 QuantizedLayer,
                                                  QuantizedEmbedding,
                                                  QuantizedLinear)
+
+logger = logging.getLogger(__name__)
+
+QUANT_WEIGHTS_NAME = "quant_pytorch_model.bin"
 
 QUANT_BERT_PRETRAINED_CONFIG_ARCHIVE_MAP = {
     'bert-base-uncased': "https://nlp-architect-data.s3-us-west-2.amazonaws.com/models/transformers/bert-base-uncased.json",  # noqa: E501
@@ -194,6 +202,95 @@ class QuantizedBertPreTrainedModel(BertPreTrainedModel):
             module.weight.data.fill_(1.0)
         if isinstance(module, nn.Linear) and module.bias is not None:
             module.bias.data.zero_()
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *args, from_8bit=False, **kwargs):
+        """load trained model from 8bit model"""
+        if not from_8bit:
+            return super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        config = kwargs.pop('config', None)
+        output_loading_info = kwargs.pop('output_loading_info', False)
+
+        # Load config
+        if config is None:
+            config = cls.config_class.from_pretrained(
+                pretrained_model_name_or_path, *args, **kwargs)
+
+        # Load model
+        model_dir = os.path.join(pretrained_model_name_or_path, QUANT_WEIGHTS_NAME)
+
+        # Instantiate model.
+        model = cls(config)
+        # Set model in evaluation mode to desactivate DropOut modules by default
+        model.eval()
+        # Get state dict of model
+        state_dict = torch.load(model_dir, map_location='cpu')
+
+        # Load from a PyTorch state_dict
+        missing_keys = []
+        unexpected_keys = []
+        error_msgs = []
+        # copy state_dict so _load_from_state_dict can modify it
+        metadata = getattr(state_dict, '_metadata', None)
+        state_dict = state_dict.copy()
+        if metadata is not None:
+            state_dict._metadata = metadata
+
+        def load(module, prefix=''):
+            local_metadata = {} if metadata is None else metadata.get(prefix[:-1], {})
+            module._load_from_state_dict(
+                state_dict, prefix, local_metadata, True, missing_keys, unexpected_keys, error_msgs)
+            for name, child in module._modules.items():
+                if child is not None:
+                    load(child, prefix + name + '.')
+
+        # Make sure we are able to load base models as well as derived models (with heads)
+        start_prefix = ''
+        model_to_load = model
+        if not hasattr(model, cls.base_model_prefix) and any(s.startswith(cls.base_model_prefix) for s in state_dict.keys()):
+            start_prefix = cls.base_model_prefix + '.'
+        if hasattr(model, cls.base_model_prefix) and not any(s.startswith(cls.base_model_prefix) for s in state_dict.keys()):
+            model_to_load = getattr(model, cls.base_model_prefix)
+
+        load(model_to_load, prefix=start_prefix)
+        if len(missing_keys) > 0:
+            logger.info("Weights of {} not initialized from pretrained model: {}".format(
+                model.__class__.__name__, missing_keys))
+        if len(unexpected_keys) > 0:
+            logger.info("Weights from pretrained model not used in {}: {}".format(
+                model.__class__.__name__, unexpected_keys))
+        if len(error_msgs) > 0:
+            raise RuntimeError('Error(s) in loading state_dict for {}:\n\t{}'.format(
+                               model.__class__.__name__, "\n\t".join(error_msgs)))
+
+        if hasattr(model, 'tie_weights'):
+            model.tie_weights()  # make sure word embedding weights are still tied
+
+        if output_loading_info:
+            loading_info = {"missing_keys": missing_keys,
+                            "unexpected_keys": unexpected_keys, "error_msgs": error_msgs}
+            return model, loading_info
+
+        return model
+
+    def save_pretrained(self, save_directory):
+        """save trained model in 8bit"""
+        super().save_pretrained(save_directory)
+        # Only save the model it-self if we are using distributed training
+        model_to_save = self.module if hasattr(self, 'module') else self
+        model_to_save.apply(model_to_save._toggle_8bit)
+        training = model_to_save.training
+        model_to_save.eval()
+        output_model_file = os.path.join(save_directory, QUANT_WEIGHTS_NAME)
+        torch.save(model_to_save.state_dict(), output_model_file)
+        model_to_save.apply(model_to_save._toggle_8bit)
+        model_to_save.train(training)
+
+    @staticmethod
+    def _toggle_8bit(module):
+        """funtion to be applied on the module in order to activate 8bit using module.apply"""
+        if isinstance(module, QuantizedLayer):
+            module.toggle_8bit()
 
 
 class QuantizedBertModel(QuantizedBertPreTrainedModel, BertModel):

--- a/nlp_architect/models/transformers/sequence_classification.py
+++ b/nlp_architect/models/transformers/sequence_classification.py
@@ -54,7 +54,7 @@ class TransformerSequenceClassifier(TransformerBase):
     }
 
     def __init__(self, model_type: str, labels: List[str] = None,
-                 task_type="classification", metric_fn=accuracy, quant_infer=False,
+                 task_type="classification", metric_fn=accuracy, load_quantized=False,
                  *args, **kwargs):
         assert model_type in self.MODEL_CLASS.keys(), "unsupported model type"
         self.labels = labels
@@ -65,7 +65,7 @@ class TransformerSequenceClassifier(TransformerBase):
                                                             **kwargs)
         self.model_class = self.MODEL_CLASS[model_type]
         self.model = self.model_class.from_pretrained(self.model_name_or_path, from_tf=bool(
-            '.ckpt' in self.model_name_or_path), config=self.config, from_8bit=quant_infer)
+            '.ckpt' in self.model_name_or_path), config=self.config, from_8bit=load_quantized)
         self.task_type = task_type
         self.metric_fn = metric_fn
         self.to(self.device, self.n_gpus)

--- a/nlp_architect/models/transformers/sequence_classification.py
+++ b/nlp_architect/models/transformers/sequence_classification.py
@@ -54,7 +54,7 @@ class TransformerSequenceClassifier(TransformerBase):
     }
 
     def __init__(self, model_type: str, labels: List[str] = None,
-                 task_type="classification", metric_fn=accuracy,
+                 task_type="classification", metric_fn=accuracy, quant_infer=False,
                  *args, **kwargs):
         assert model_type in self.MODEL_CLASS.keys(), "unsupported model type"
         self.labels = labels
@@ -65,7 +65,7 @@ class TransformerSequenceClassifier(TransformerBase):
                                                             **kwargs)
         self.model_class = self.MODEL_CLASS[model_type]
         self.model = self.model_class.from_pretrained(self.model_name_or_path, from_tf=bool(
-            '.ckpt' in self.model_name_or_path), config=self.config)
+            '.ckpt' in self.model_name_or_path), config=self.config, from_8bit=quant_infer)
         self.task_type = task_type
         self.metric_fn = metric_fn
         self.to(self.device, self.n_gpus)

--- a/nlp_architect/models/transformers/token_classification.py
+++ b/nlp_architect/models/transformers/token_classification.py
@@ -104,7 +104,7 @@ class TransformerTokenClassifier(TransformerBase):
         'xlnet': XLNetForTokenClassification,
     }
 
-    def __init__(self, model_type: str, labels: List[str] = None, *args, quant_infer=False, **kwargs):
+    def __init__(self, model_type: str, labels: List[str] = None, *args, load_quantized=False, **kwargs):
         assert model_type in self.MODEL_CLASS.keys(), "unsupported model type"
         self.labels = labels
         self.num_labels = len(labels) + 1  # +1 for padding label
@@ -117,7 +117,7 @@ class TransformerTokenClassifier(TransformerBase):
 
         self.model_class = self.MODEL_CLASS[model_type]
         self.model = self.model_class.from_pretrained(self.model_name_or_path, from_tf=bool(
-            '.ckpt' in self.model_name_or_path), config=self.config, from_8bit=quant_infer)
+            '.ckpt' in self.model_name_or_path), config=self.config, from_8bit=load_quantized)
         self.to(self.device, self.n_gpus)
 
     def train(self,

--- a/nlp_architect/models/transformers/token_classification.py
+++ b/nlp_architect/models/transformers/token_classification.py
@@ -104,7 +104,7 @@ class TransformerTokenClassifier(TransformerBase):
         'xlnet': XLNetForTokenClassification,
     }
 
-    def __init__(self, model_type: str, labels: List[str] = None, *args, **kwargs):
+    def __init__(self, model_type: str, labels: List[str] = None, *args, quant_infer=False, **kwargs):
         assert model_type in self.MODEL_CLASS.keys(), "unsupported model type"
         self.labels = labels
         self.num_labels = len(labels) + 1  # +1 for padding label
@@ -117,7 +117,7 @@ class TransformerTokenClassifier(TransformerBase):
 
         self.model_class = self.MODEL_CLASS[model_type]
         self.model = self.model_class.from_pretrained(self.model_name_or_path, from_tf=bool(
-            '.ckpt' in self.model_name_or_path), config=self.config)
+            '.ckpt' in self.model_name_or_path), config=self.config, from_8bit=quant_infer)
         self.to(self.device, self.n_gpus)
 
     def train(self,

--- a/nlp_architect/nn/torch/quantization.py
+++ b/nlp_architect/nn/torch/quantization.py
@@ -249,18 +249,11 @@ class QuantizedEmbedding(QuantizedLayer, nn.Embedding):
 
 class QuantizationConfig(Config):
     """Quantization Configuration Object"""
-
-    def __init__(self,
-                 activation_bits=8,
-                 weight_bits=8,
-                 mode='none',
-                 start_step=0,
-                 ema_decay=0.9999,
-                 requantize_output=True
-                 ):
-        self.activation_bits = activation_bits
-        self.weight_bits = weight_bits
-        self.mode = mode
-        self.start_step = start_step
-        self.ema_decay = ema_decay
-        self.requantize_output = requantize_output
+    ATTRIBUTES = {
+        "activation_bits": 8,
+        "weight_bits": 8,
+        "mode": "none",
+        "start_step": 0,
+        "ema_decay": 0.999,
+        "requantize_output": True
+    }

--- a/nlp_architect/procedures/transformers/base.py
+++ b/nlp_architect/procedures/transformers/base.py
@@ -62,6 +62,8 @@ def inference_args(parser: argparse.ArgumentParser):
     """
     parser.add_argument("--model_path", default=None, type=str, required=True,
                         help="Path to pre-trained model")
+    parser.add_argument("--quantized_inference", action="store_true",
+                        help="Perform Inference from saved quantized model, 'quant_pytorch_model.bin' file must exist in directory and model type must be 'quant_bert'")
 
 
 def train_args(parser: argparse.ArgumentParser, models_family=None):

--- a/nlp_architect/procedures/transformers/base.py
+++ b/nlp_architect/procedures/transformers/base.py
@@ -62,8 +62,8 @@ def inference_args(parser: argparse.ArgumentParser):
     """
     parser.add_argument("--model_path", default=None, type=str, required=True,
                         help="Path to pre-trained model")
-    parser.add_argument("--quantized_inference", action="store_true",
-                        help="Perform Inference from saved quantized model, 'quant_pytorch_model.bin' file must exist in directory and model type must be 'quant_bert'")
+    parser.add_argument("--load_quantized_model", action="store_true",
+                        help="Load and perform Inference from saved quantized model, 'quant_pytorch_model.bin' file must exist in directory and model type must be 'quant_<model>'")
 
 
 def train_args(parser: argparse.ArgumentParser, models_family=None):

--- a/nlp_architect/procedures/transformers/glue.py
+++ b/nlp_architect/procedures/transformers/glue.py
@@ -142,7 +142,8 @@ def do_inference(args):
     classifier = TransformerSequenceClassifier.load_model(model_path=args.model_path,
                                                           model_type=args.model_type,
                                                           metric_fn=get_metric_fn(task.name),
-                                                          do_lower_case=args.do_lower_case)
+                                                          do_lower_case=args.do_lower_case,
+                                                          quant_infer=args.quantized_inference)
     classifier.to(device, n_gpus)
     examples = task.get_dev_examples() if args.evaluate else \
         task.get_test_examples()

--- a/nlp_architect/procedures/transformers/glue.py
+++ b/nlp_architect/procedures/transformers/glue.py
@@ -143,7 +143,7 @@ def do_inference(args):
                                                           model_type=args.model_type,
                                                           metric_fn=get_metric_fn(task.name),
                                                           do_lower_case=args.do_lower_case,
-                                                          quant_infer=args.quantized_inference)
+                                                          load_quantized=args.load_quantized_model)
     classifier.to(device, n_gpus)
     examples = task.get_dev_examples() if args.evaluate else \
         task.get_test_examples()

--- a/nlp_architect/procedures/transformers/seq_tag.py
+++ b/nlp_architect/procedures/transformers/seq_tag.py
@@ -148,7 +148,7 @@ def do_inference(args):
     classifier = TransformerTokenClassifier.load_model(model_path=args.model_path,
                                                        model_type=args.model_type,
                                                        do_lower_case=args.do_lower_case,
-                                                       quant_infer=args.quantized_inference)
+                                                       load_quantized=args.load_quantized_model)
     classifier.to(device, n_gpus)
     output = classifier.inference(inference_examples, args.batch_size)
     write_column_tagged_file(args.output_dir + os.sep + "output.txt", output)

--- a/nlp_architect/procedures/transformers/seq_tag.py
+++ b/nlp_architect/procedures/transformers/seq_tag.py
@@ -146,7 +146,9 @@ def do_inference(args):
     args.batch_size = args.per_gpu_eval_batch_size * max(1, n_gpus)
     inference_examples = process_inference_input(args.data_file)
     classifier = TransformerTokenClassifier.load_model(model_path=args.model_path,
-                                                       model_type=args.model_type)
+                                                       model_type=args.model_type,
+                                                       do_lower_case=args.do_lower_case,
+                                                       quant_infer=args.quantized_inference)
     classifier.to(device, n_gpus)
     output = classifier.inference(inference_examples, args.batch_size)
     write_column_tagged_file(args.output_dir + os.sep + "output.txt", output)

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -123,33 +123,33 @@ class QuantizedLinearTest(unittest.TestCase):
         self.assertEqual(qlinear.input_thresh, input_ema)
         self.assertEqual(qlinear.output_thresh, output_ema)
 
-    # def test_ema_quantization_data_parallel(self):
-    #     # TODO(ofir) this test only works with 4gpus, need to fix it to
-    #     #            adapt to the number of gpus available
-    #     if not torch.cuda.is_available():
-    #         return
-    #     ema_decay = 0.9
-    #     fake_quantize = FakeLinearQuantizationWithSTE().apply
-    #     qlinear = nn.DataParallel(QuantizedLinear(
-    #         10, 5, bias=False, ema_decay=ema_decay, mode="EMA")).cuda()
-    #     for i in range(5):
-    #         x = torch.randn(3, 10).cuda()
-    #         tmp_input_thresh = x[0].abs().max()
-    #         if i == 0:
-    #             input_ema = tmp_input_thresh
-    #         else:
-    #             input_ema -= (1 - ema_decay) * (input_ema - tmp_input_thresh)
-    #         y = (fake_quantize(x, get_scale(8, input_ema), 8)
-    #              @ qlinear.module.fake_quantized_weight.t()).detach()
-    #         tmp_output_thresh = y[0].abs().max()
-    #         if i == 0:
-    #             output_ema = tmp_output_thresh
-    #         else:
-    #             output_ema -= (1 - ema_decay) * \
-    #                           (output_ema - tmp_output_thresh)
-    #         qlinear(x)
-    #     self.assertEqual(qlinear.module.input_thresh, input_ema)
-    #     self.assertEqual(qlinear.module.output_thresh, output_ema)
+    def test_ema_quantization_data_parallel(self):
+        # TODO(ofir) this test only works with 4gpus, need to fix it to
+        #            adapt to the number of gpus available
+        if not torch.cuda.is_available() or torch.cuda.device_count() <= 1:
+            return
+        ema_decay = 0.9
+        fake_quantize = FakeLinearQuantizationWithSTE().apply
+        qlinear = nn.DataParallel(QuantizedLinear(
+            10, 5, bias=False, ema_decay=ema_decay, mode="EMA")).cuda()
+        for i in range(5):
+            x = torch.randn(2, 10).cuda()
+            tmp_input_thresh = x[0].abs().max()
+            if i == 0:
+                input_ema = tmp_input_thresh
+            else:
+                input_ema -= (1 - ema_decay) * (input_ema - tmp_input_thresh)
+            y = (fake_quantize(x, get_scale(8, input_ema), 8)
+                 @ qlinear.module.fake_quantized_weight.t()).detach()
+            tmp_output_thresh = y[0].abs().max()
+            if i == 0:
+                output_ema = tmp_output_thresh
+            else:
+                output_ema -= (1 - ema_decay) * \
+                              (output_ema - tmp_output_thresh)
+            qlinear(x)
+        self.assertEqual(qlinear.module.input_thresh, input_ema)
+        self.assertEqual(qlinear.module.output_thresh, output_ema)
 
     def test_start_quantization_delay(self):
         quantization_delay = 2

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -124,6 +124,7 @@ class QuantizedLinearTest(unittest.TestCase):
         self.assertEqual(qlinear.output_thresh, output_ema)
 
     def test_ema_quantization_data_parallel(self):
+        # TODO(ofir) this test is for 3+ gpus configuration, fix it to be more general
         if not torch.cuda.is_available():
             return
         ema_decay = 0.9
@@ -218,6 +219,99 @@ class QuantizedLinearTest(unittest.TestCase):
         y_hat = qlinear(x)
         self.assertTrue((y - y_hat).norm() < 1e-6)
 
+    def test_export_to_8bit_with_bias(self):
+        qlinear = QuantizedLinear(10, 5, mode='EMA')
+        qlinear.eval()
+        state_dict = qlinear.state_dict()
+        self.assertTrue('weight' in state_dict)
+        self.assertTrue('bias' in state_dict)
+        self.assertTrue('quantized_weight' in state_dict)
+        self.assertTrue(state_dict['quantized_weight'].dtype == torch.float32)
+        self.assertTrue('_quantized_bias' in state_dict)
+        self.assertTrue(state_dict['_quantized_bias'].dtype == torch.float32)
+        self.assertTrue('bias_scale' in state_dict)
+        qlinear.activate_8bit()
+        state_dict = qlinear.state_dict()
+        self.assertTrue('weight' not in state_dict)
+        self.assertTrue('bias' not in state_dict)
+        self.assertTrue('quantized_weight' in state_dict)
+        self.assertTrue(state_dict['quantized_weight'].dtype == torch.int8)
+        self.assertTrue('_quantized_bias' in state_dict)
+        self.assertTrue(state_dict['_quantized_bias'].dtype == torch.int32)
+        self.assertTrue('bias_scale' in state_dict)
+        qlinear.deactivate_8bit()
+        state_dict = qlinear.state_dict()
+        self.assertTrue('weight' in state_dict)
+        self.assertTrue('bias' in state_dict)
+        self.assertTrue('quantized_weight' in state_dict)
+        self.assertTrue(state_dict['quantized_weight'].dtype == torch.float32)
+        self.assertTrue('_quantized_bias' in state_dict)
+        self.assertTrue(state_dict['_quantized_bias'].dtype == torch.float32)
+        self.assertTrue('bias_scale' in state_dict)
+
+    def test_export_to_8bit_without_bias(self):
+        qlinear = QuantizedLinear(10, 5, bias=False, mode='EMA')
+        qlinear.eval()
+        qlinear.activate_8bit()
+        state_dict = qlinear.state_dict()
+        self.assertTrue('weight' not in state_dict)
+        self.assertTrue('bias' not in state_dict)
+        self.assertTrue('quantized_weight' in state_dict)
+        self.assertTrue(state_dict['quantized_weight'].dtype == torch.int8)
+        self.assertTrue('_quantized_bias' not in state_dict)
+        self.assertTrue('bias_scale' not in state_dict)
+        qlinear.deactivate_8bit()
+        state_dict = qlinear.state_dict()
+        self.assertTrue('weight' in state_dict)
+        self.assertTrue('bias' not in state_dict)
+        self.assertTrue('quantized_weight' in state_dict)
+        self.assertTrue(state_dict['quantized_weight'].dtype == torch.float32)
+        self.assertTrue('_quantized_bias' not in state_dict)
+        self.assertTrue('bias_scale' not in state_dict)
+
+    def test_import_to_8bit_without_bias(self):
+        exporter = QuantizedLinear(10, 5, bias=False, mode='dynamic')
+        exporter.eval()
+        exporter.activate_8bit()
+        state_dict = exporter.state_dict()
+        exporter.deactivate_8bit()
+        importer = QuantizedLinear(10, 5, bias=False, mode='dynamic')
+        self.assertTrue((exporter.weight != importer.weight).any())
+        importer.eval()
+        importer.load_state_dict(state_dict, strict=False)
+        x = torch.randn(3, 10)
+        self.assertTrue((exporter(x) == importer(x)).all())
+
+    def test_import_to_8bit_with_bias(self):
+        # QuantizationMode dynamic
+        exporter = QuantizedLinear(10, 5, mode='dynamic')
+        exporter.eval()
+        exporter.activate_8bit()
+        state_dict = exporter.state_dict()
+        exporter.deactivate_8bit()
+        importer = QuantizedLinear(10, 5, mode='dynamic')
+        self.assertTrue((exporter.weight != importer.weight).any())
+        self.assertTrue((exporter.bias != importer.bias).any())
+        importer.eval()
+        importer.load_state_dict(state_dict, strict=False)
+        x = torch.randn(3, 10)
+        self.assertTrue((exporter(x) == importer(x)).all())
+        # QuantizationMode ema
+        exporter = QuantizedLinear(10, 5, requantize_output=False, mode='ema')
+        x = torch.randn(3, 10)
+        exporter(x)
+        self.assertTrue(exporter.input_thresh != 0.)
+        exporter.eval()
+        exporter.activate_8bit()
+        state_dict = exporter.state_dict()
+        exporter.deactivate_8bit()
+        importer = QuantizedLinear(10, 5, requantize_output=False, mode='ema')
+        self.assertTrue((exporter.weight != importer.weight).any())
+        self.assertTrue((exporter.bias != importer.bias).any())
+        importer.eval()
+        importer.load_state_dict(state_dict, strict=False)
+        self.assertTrue((exporter(x) == importer(x)).all())
+
 
 class QuantizedEmbeddingTest(unittest.TestCase):
     def test_quantized_embedding_training_forward(self):
@@ -274,3 +368,38 @@ class QuantizedEmbeddingTest(unittest.TestCase):
         indices = torch.tensor(np.arange(10))
         self.assertTrue((embedding(indices) == qembedding(indices)).all())
         self.assertTrue((embedding(indices) == qembedding(indices)).all())
+
+    def test_export_to_8bit(self):
+        qembed = QuantizedEmbedding(10, 5, mode='EMA')
+        qembed.eval()
+        state_dict = qembed.state_dict()
+        self.assertTrue('quantized_weight' in state_dict)
+        self.assertTrue(state_dict['quantized_weight'].dtype == torch.float32)
+        self.assertTrue('weight' in state_dict)
+        qembed.activate_8bit()
+        state_dict = qembed.state_dict()
+        self.assertTrue('quantized_weight' in state_dict)
+        self.assertTrue(state_dict['quantized_weight'].dtype == torch.int8)
+        self.assertTrue('weight' not in state_dict)
+        qembed.deactivate_8bit()
+        state_dict = qembed.state_dict()
+        self.assertTrue('quantized_weight' in state_dict)
+        self.assertTrue(state_dict['quantized_weight'].dtype == torch.float32)
+        self.assertTrue('weight' in state_dict)
+
+    def test_load_from_8bit(self):
+        exporter = QuantizedEmbedding(10, 5, mode='EMA')
+        exporter.eval()
+        exporter.activate_8bit()
+        state_dict = exporter.state_dict()
+        exporter.deactivate_8bit()
+        importer = QuantizedEmbedding(10, 5, mode='EMA')
+        self.assertTrue((exporter.weight != importer.weight).any())
+        importer.eval()
+        importer.load_state_dict(state_dict, strict=False)
+        indices = torch.tensor(np.arange(10))
+        self.assertTrue((exporter(indices) == importer(indices)).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -124,8 +124,6 @@ class QuantizedLinearTest(unittest.TestCase):
         self.assertEqual(qlinear.output_thresh, output_ema)
 
     def test_ema_quantization_data_parallel(self):
-        # TODO(ofir) this test only works with 4gpus, need to fix it to
-        #            adapt to the number of gpus available
         if not torch.cuda.is_available() or torch.cuda.device_count() <= 1:
             return
         ema_decay = 0.9


### PR DESCRIPTION
- Added the functionality of exporting and importing quantized trained models to 8bit format. Following #86 now training a quantized model will generate a quantized model file which is smaller by approximately 4x.
![image](https://user-images.githubusercontent.com/18296312/65462708-0776db00-de5f-11e9-8570-5b94a9ea5c83.png)
- Accelerated quantized inference performance by calculating the quantized weights offline. Following #90.
  - Note: quantized inference is still slower than FP32 inference since this is still only a simulation. Quantized inference is still done using FP32 arithmetic with quantization ops on top.
- Created a base class for quantized layers.
- Modified Config class for easier use.
- Various bug fixes related to training quantized training.

