### PR TITLE
Transformers Procedures: Remember seed when setting random seed

### DIFF
--- a/nlp_architect/nn/torch/__init__.py
+++ b/nlp_architect/nn/torch/__init__.py
@@ -34,7 +34,7 @@ def setup_backend(no_cuda):
 
 
 def set_seed(seed, n_gpus=None):
-    """set seed
+    """set and return seed
     """
     if seed == -1:
         seed = int(time.time())
@@ -43,3 +43,4 @@ def set_seed(seed, n_gpus=None):
     torch.manual_seed(seed)
     if n_gpus is not None and n_gpus > 0:
         torch.cuda.manual_seed_all(seed)
+    return seed

--- a/nlp_architect/procedures/token_tagging.py
+++ b/nlp_architect/procedures/token_tagging.py
@@ -135,7 +135,7 @@ def do_training(args):
     prepare_output_path(args.output_dir, args.overwrite_output_dir)
     device, n_gpus = setup_backend(args.no_cuda)
     # Set seed
-    set_seed(args.seed, n_gpus)
+    args.seed = set_seed(args.seed, n_gpus)
     # prepare data
     processor = TokenClsProcessor(args.data_dir, tag_col=args.tag_col)
     train_ex = processor.get_train_examples()
@@ -205,7 +205,7 @@ def do_kd_training(args):
     prepare_output_path(args.output_dir, args.overwrite_output_dir)
     device, n_gpus = setup_backend(args.no_cuda)
     # Set seed
-    set_seed(args.seed, n_gpus)
+    args.seed = set_seed(args.seed, n_gpus)
     # prepare data
     processor = TokenClsProcessor(args.data_dir, tag_col=args.tag_col)
     train_ex = processor.get_train_examples()

--- a/nlp_architect/procedures/transformers/glue.py
+++ b/nlp_architect/procedures/transformers/glue.py
@@ -84,7 +84,7 @@ def do_training(args):
     prepare_output_path(args.output_dir, args.overwrite_output_dir)
     device, n_gpus = setup_backend(args.no_cuda)
     # Set seed
-    set_seed(args.seed, n_gpus)
+    args.seed = set_seed(args.seed, n_gpus)
     # Prepare GLUE task
     args.task_name = args.task_name.lower()
     task = get_glue_task(args.task_name, data_dir=args.data_dir)

--- a/nlp_architect/procedures/transformers/seq_tag.py
+++ b/nlp_architect/procedures/transformers/seq_tag.py
@@ -76,7 +76,7 @@ def do_training(args):
     prepare_output_path(args.output_dir, args.overwrite_output_dir)
     device, n_gpus = setup_backend(args.no_cuda)
     # Set seed
-    set_seed(args.seed, n_gpus)
+    args.seed = set_seed(args.seed, n_gpus)
     # prepare data
     processor = TokenClsProcessor(args.data_dir)
 


### PR DESCRIPTION
When giving the flag `--seed -1` a random seed is picked based, however, this seed is not saved in the training arguments file.
Added functionality to save the seed that was picked in the `training_args.bin` file.